### PR TITLE
Exclude `eslint` from Dependabot group updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
+        exclude-patterns: ['eslint']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See #32 for the lint failure on CI.

> Is there anything in the PR that needs further explanation?

Because `eslint-config-stylelint` has not supported `eslint@9` yet.
