### PR TITLE
Revert "Exclude `eslint` from Dependabot group updates"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
-        exclude-patterns: ['eslint']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Reverts stylelint/stylelint-ecosystem-tester#34

ESLint v9 has been updated already:

https://github.com/stylelint/stylelint-ecosystem-tester/blob/c7abbcfd2f6f9102a4bcc5b25622bd343bdc406d/package.json#L48