### PR TITLE
Introduce cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     groups:
       development-dependencies:
         dependency-type: 'development'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: '/'
@@ -19,3 +21,5 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - 'pr: dependencies'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This aims to mitigate Supply Chain Attacks by bumping to malicious dependency versions too quickly.

Ref https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

