### PR TITLE
Remove `actionlint` job from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,3 @@ jobs:
       node-version: '["lts/*"]'
     permissions:
       contents: read
-
-  actionlint:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: docker://rhysd/actionlint:latest
-        with:
-          args: -color


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

`actionlint` has not recently been very well-maintained. Ref https://github.com/rhysd/actionlint

Additionally, using the Docker action is against our policy, which we introduced a few days ago.

```
The action `docker://rhysd/actionlint:latest` is not allowed ...
```

https://github.com/stylelint/stylelint-ecosystem-tester/actions/runs/17821481661

That's why I believe removing `actionlint` makes sense.
