### PR TITLE
Revert "Work around npm v11.12.0 issue"

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -73,11 +73,8 @@ jobs:
           package-manager-cache: false
 
       - name: Install latest npm
-        # TODO: Revert the version constraint to "latest" after the issue is resolved.
-        # npm v11.12.0 fails to install packages from GitHub.
-        # Ref https://github.com/npm/cli/issues/9133
         run: |
-          npm install --global npm@'<11.12.0'
+          npm install --global npm@latest
           echo "npm: $(npm --version)"
 
       - name: Install pnpm


### PR DESCRIPTION
Reverts stylelint/stylelint-ecosystem-tester#117

> [!CAUTION]
> ~~Blocked until npm v11.12.1 is out. Ref:~~
> - ~~https://github.com/npm/cli/pull/9143~~


> [!IMPORTANT]
> [v11.12.1](https://github.com/npm/cli/releases/tag/v11.12.1) has been released!