### PR TITLE
Allow Git installs for Stylelint version

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -118,7 +118,10 @@ jobs:
           STYLELINT_VERSION: ${{ inputs.stylelint-version }}
           PACKAGE_URL: ${{ steps.repo-info.outputs.url }}
         run: |
-          if ! npm install --no-audit --no-save "${STYLELINT_VERSION}"; then
+          # NOTE: `--min-release-age=0` doesn't work with npm v11.13.0 for some reason.
+          npm config --location=project delete min-release-age
+
+          if ! npm install --no-audit --no-save --allow-git=all "${STYLELINT_VERSION}"; then
             echo "::error ::The Stylelint (${STYLELINT_VERSION}) installation failed. Visit ${PACKAGE_URL}"
             exit 1
           fi


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates #130

> Is there anything in the PR that needs further explanation?

This supports installing Stylelint from a Git ref (e.g. `stylelint/stylelint`) via `--allow-git=all`.

Also, it temporarily drops project-level `min-release-age` first because npm injects `--before`, which conflicts with `--min-release-age=0`.

For example, here is a failed CI log:

```
npm error code EALLOWGIT
npm error Fetching packages of type "git" have been disabled
npm error Refusing to fetch "github:stylelint/stylelint"
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-05-06T02_57_52_415Z-debug-0.log
Error: The Stylelint (stylelint/stylelint) installation failed. Visit https://github.com/stylelint/stylelint-config-recommended
```

Ref: https://github.com/stylelint/stylelint-ecosystem-tester/actions/runs/25414020290/job/74541525298
