### PR TITLE
Test against latest Node.js instead of LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   test:
     uses: stylelint/.github/.github/workflows/call-test.yml@6ac761787832e417273f7bb071ec8cf35abcc3d6 # 1.0.0
     with:
-      node-version: '["lts/*"]'
+      node-version: '["latest"]'
     permissions:
       contents: read
 

--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: node
+          node-version: latest
           cache: npm
 
       - name: Install dependencies
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: node
+          node-version: latest
           # NOTE: To avoid the error "Unable to locate executable file: pnpm", it disables cache.
           # Ref https://github.com/actions/setup-node/issues/1357
           package-manager-cache: false
@@ -273,7 +273,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: node
+          node-version: latest
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Relates to <https://github.com/stylelint/stylelint/pull/9398>

> Is there anything in the PR that needs further explanation?

I think the latest version is also stable and safe for our CI.

> [!NOTE]
> `node-version: node` equals `latest` in `actions/setup`.

