### PR TITLE
Re-enable `stylelint-config-standard-vue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Each package is tested daily against the latest and next Stylelint by the [test 
 | `stylelint-config-recommended-vue`                  | [![stylelint-config-recommended-vue](https://img.shields.io/npm/v/stylelint-config-recommended-vue.svg)](https://www.npmjs.com/package/stylelint-config-recommended-vue)                                                    |        ✅         |       ✅       |
 | `stylelint-config-sass-guidelines`                  | [![stylelint-config-sass-guidelines](https://img.shields.io/npm/v/stylelint-config-sass-guidelines.svg)](https://www.npmjs.com/package/stylelint-config-sass-guidelines)                                                    |        ❌         |       ❌       |
 | `stylelint-config-standard-scss`                    | [![stylelint-config-standard-scss](https://img.shields.io/npm/v/stylelint-config-standard-scss.svg)](https://www.npmjs.com/package/stylelint-config-standard-scss)                                                          |        ✅         |       ✅       |
+| `stylelint-config-standard-vue`                     | [![stylelint-config-standard-vue](https://img.shields.io/npm/v/stylelint-config-standard-vue.svg)](https://www.npmjs.com/package/stylelint-config-standard-vue)                                                             |        ❌         |       ❌       |
 | `stylelint-config-suitcss`                          | [![stylelint-config-suitcss](https://img.shields.io/npm/v/stylelint-config-suitcss.svg)](https://www.npmjs.com/package/stylelint-config-suitcss)                                                                            |        ❌         |       ❌       |
 | `stylelint-config-twbs-bootstrap`                   | [![stylelint-config-twbs-bootstrap](https://img.shields.io/npm/v/stylelint-config-twbs-bootstrap.svg)](https://www.npmjs.com/package/stylelint-config-twbs-bootstrap)                                                       |        ❌         |       ❌       |
 | `stylelint-config-wikimedia`                        | [![stylelint-config-wikimedia](https://img.shields.io/npm/v/stylelint-config-wikimedia.svg)](https://www.npmjs.com/package/stylelint-config-wikimedia)                                                                      |        ✅         |       ✅       |
@@ -65,10 +66,10 @@ Each package is tested daily against the latest and next Stylelint by the [test 
 | `stylelint-use-nesting`                             | [![stylelint-use-nesting](https://img.shields.io/npm/v/stylelint-use-nesting.svg)](https://www.npmjs.com/package/stylelint-use-nesting)                                                                                     |        ✅         |       ✅       |
 | `stylelint-value-no-unknown-custom-properties`      | [![stylelint-value-no-unknown-custom-properties](https://img.shields.io/npm/v/stylelint-value-no-unknown-custom-properties.svg)](https://www.npmjs.com/package/stylelint-value-no-unknown-custom-properties)                |        ✅         |       ✅       |
 
-Total 44 packages.
+Total 45 packages.
 
-- **Stylelint 17.14.1**: ✅ 35 passed, ❌ 9 failed
-- **Stylelint HEAD**: ✅ 35 passed, ❌ 9 failed
+- **Stylelint 17.14.1**: ✅ 35 passed, ❌ 10 failed
+- **Stylelint HEAD**: ✅ 35 passed, ❌ 10 failed
 <!-- END:PACKAGES -->
 
 > [!NOTE]

--- a/data/ecosystem.yml
+++ b/data/ecosystem.yml
@@ -34,7 +34,7 @@ packages:
   stylelint-config-recommended-vue: {}
   stylelint-config-sass-guidelines: {}
   stylelint-config-standard-scss: {}
-  # stylelint-config-standard-vue: {}
+  stylelint-config-standard-vue: {}
   stylelint-config-suitcss: {}
   stylelint-config-twbs-bootstrap: {}
   stylelint-config-wikimedia: {}

--- a/data/test-results.yml
+++ b/data/test-results.yml
@@ -98,6 +98,11 @@ stylelint-config-standard-scss:
     status: success
   next:
     status: success
+stylelint-config-standard-vue:
+  latest:
+    status: failure
+  next:
+    status: failure
 stylelint-config-suitcss:
   latest:
     status: failure


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

Closes #48 (duplicate)

> Is there anything in the PR that needs further explanation?

Since `stylelint-config-recommended-vue` has already been present, `stylelint-config-standard-vue` should also be enabled.

---

Triggered the test workflow:
https://github.com/stylelint/stylelint-ecosystem-tester/actions/runs/29747504280/job/88369240644

The installation passed, but the test failed. However, the failure reason seems to be due to test fixtures that rely on older Stylelint versions, so it's not a significant problem.