### PR TITLE
Add `corepack` option to `ecosystem.yml`

### DIFF
--- a/.github/workflows/test-ecosystem.yml
+++ b/.github/workflows/test-ecosystem.yml
@@ -120,8 +120,15 @@ jobs:
           npm install --global npm@latest
           echo "npm: $(npm --version)"
 
+      - name: Install Corepack
+        if: ${{ steps.info.outputs.corepack }}
+        run: |
+          npm install --global corepack
+          echo "corepack: $(corepack --version)"
+          corepack enable
+
       - name: Install pnpm
-        if: ${{ steps.info.outputs.package-manager == 'pnpm' }}
+        if: ${{ steps.info.outputs.package-manager == 'pnpm' && !steps.info.outputs.corepack }}
         env:
           STYLELINT_PACKAGE_SPEC: ${{ steps.info.outputs.stylelint-package-spec }}
         run: |
@@ -135,7 +142,7 @@ jobs:
           pnpm config get --location=project --json overrides
 
       - name: Install yarn
-        if: ${{ steps.info.outputs.package-manager == 'yarn' }}
+        if: ${{ steps.info.outputs.package-manager == 'yarn' && !steps.info.outputs.corepack }}
         run: |
           npm install --global yarn
           echo "yarn: $(yarn --version)"

--- a/data/ecosystem.yml
+++ b/data/ecosystem.yml
@@ -1,3 +1,9 @@
+# Attributes:
+# - official (boolean): Whether it's an official Stylelint package.
+# - package-manager (enum): npm, pnpm, or, yarn.
+# - corepack (boolean): Whether to use Corepack.
+# - test-command (string): Command to run tests.
+
 packages:
   # Official
   stylelint-config-recommended:


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

See <https://github.com/stylelint/stylelint-ecosystem-tester/pull/167#issuecomment-5043071912>. This option might resolve the issue. -> Resolved. ✅ 

> Is there anything in the PR that needs further explanation?

It controls whether to use Corepack for third-party package managers, such as pnpm.

Ref: https://github.com/nodejs/corepack
