### PR TITLE
Specify explicit `min-release-age` for `npm install`

### DIFF
--- a/scripts/prepare-test.js
+++ b/scripts/prepare-test.js
@@ -33,7 +33,8 @@ if (inputPackageNames.size > 0) {
 
 const DEFAULT_PACKAGE_INFO = {
 	'install-deps-command': 'npm install --ignore-scripts --no-audit',
-	'install-stylelint-command': 'npm install --ignore-scripts --no-audit --no-save --allow-git=all',
+	'install-stylelint-command':
+		'npm install --ignore-scripts --no-audit --no-save --allow-git=all --min-release-age=1',
 	'list-command': 'npm list stylelint',
 	'build-command': 'npm run --if-present build',
 	'test-command': 'npm test',
@@ -42,6 +43,7 @@ const DEFAULT_PACKAGE_INFO = {
 const ADVANCED_PACKAGE_INFO = {
 	pnpm: {
 		'install-deps-command': 'pnpm install --ignore-scripts --no-frozen-lockfile',
+		// TODO: Add --min-release-age after it's implemented. Ref: https://github.com/pnpm/pnpm/issues/11224
 		'install-stylelint-command': 'pnpm add --ignore-scripts',
 		'list-command': 'pnpm list stylelint',
 		'build-command': 'pnpm run --if-present build',
@@ -49,6 +51,7 @@ const ADVANCED_PACKAGE_INFO = {
 	},
 	yarn: {
 		'install-deps-command': 'yarn install --ignore-scripts',
+		// NOTE: Yarn v1 doesn't have a flag like --min-release-age, although Yarn v2 has --no-time-gate.
 		'install-stylelint-command': 'yarn add --ignore-scripts --pure-lockfile',
 		'list-command': 'yarn list --pattern stylelint',
 	},


### PR DESCRIPTION
<!-- Each pull request must be associated with an open issue unless it's a documentation fix. If a corresponding issue does not exist, please create one so we can discuss the change first. -->

<!-- Please answer the following. We close pull requests that don't. -->

> Which issue, if any, is this issue related to?

None.

> Is there anything in the PR that needs further explanation?

This PR prevents the following error on `npm install`:

```
npm error code ETARGET
npm error notarget No matching version found for @csstools/css-syntax-patches-for-csstree@^1.1.8 with a date before 8/13/2026, 2:51:35 AM.
npm error notarget In most cases you or one of your dependencies are requesting a package version that doesn't exist.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-08-20T02_51_35_250Z-debug-0.log
Error: 'npm install --ignore-scripts --no-audit --no-save --allow-git=all github:stylelint/stylelint' failed. Visit https://github.com/stylelint-scss/stylelint-scss
Error: Process completed with exit code 1.
```

Ref: https://github.com/stylelint/stylelint-ecosystem-tester/actions/runs/32326072552/job/96297569415#step:10:13

Cause: `stylelint-scss` sets `min-release-age=7`, which fails `npm install github:stylelint/stylelint`.
Ref: https://github.com/stylelint-scss/stylelint-scss/blob/0b490637d921e46c96d2bb2847498a0b083e1547/.npmrc#L2

